### PR TITLE
handle undefined navigator.mimeTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const globalCount = (() => {
   return count
 }())
 
-const navi = navigator.mimeTypes.length + navigator.userAgent.length
+const navi = (navigator.mimeTypes ? navigator.mimeTypes.length : 0) + navigator.userAgent.length
 
 const fingerprint = pad(navi.toString(36) + globalCount.toString(36), 4)
 


### PR DESCRIPTION
In a Service Worker `navigator.mimeTypes` is `undefined`, and this will throw an error.